### PR TITLE
Limit amount of objects on first load

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,23 +1,24 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
     ],
-    "hash": "f1f6640d0e2b34f9c9fdb03328081028",
+    "content-hash": "26fb54265b99b10b8b785a199fbc3ff9",
     "packages": [],
     "packages-dev": [
         {
             "name": "heroku/heroku-buildpack-php",
-            "version": "v49",
+            "version": "v173",
             "source": {
                 "type": "git",
                 "url": "https://github.com/heroku/heroku-buildpack-php.git",
-                "reference": "0adff36b9d648a3f836271fb7a6dc7eafff74356"
+                "reference": "fd5ac6063236102038d06f91b938b62b6e60080f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/heroku/heroku-buildpack-php/zipball/0adff36b9d648a3f836271fb7a6dc7eafff74356",
-                "reference": "0adff36b9d648a3f836271fb7a6dc7eafff74356",
+                "url": "https://api.github.com/repos/heroku/heroku-buildpack-php/zipball/fd5ac6063236102038d06f91b938b62b6e60080f",
+                "reference": "fd5ac6063236102038d06f91b938b62b6e60080f",
                 "shasum": ""
             },
             "bin": [
@@ -38,7 +39,7 @@
                 }
             ],
             "description": "Toolkit for starting a PHP application locally, with or without foreman, using the same config for PHP/HHVM and Apache2/Nginx as on Heroku",
-            "homepage": "http://github.com/heroku/heroku-buildpack-php",
+            "homepage": "https://github.com/heroku/heroku-buildpack-php",
             "keywords": [
                 "apache",
                 "apache2",
@@ -48,12 +49,15 @@
                 "nginx",
                 "php"
             ],
-            "time": "2014-11-28 14:22:06"
+            "time": "2020-03-20T18:09:19+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/www/libs/s3-php/S3.php
+++ b/www/libs/s3-php/S3.php
@@ -80,7 +80,7 @@ class S3
 	 * Default delimiter to be used, for example while getBucket().
 	 * @var string
 	 * @access public
-	 * @static 
+	 * @static
 	 */
 	public static $defDelimiter = null;
 
@@ -153,7 +153,7 @@ class S3
 	 * @static
 	 */
 	public static $sslKey = null;
-	
+
 	/**
 	 * SSL client certfificate
 	 *
@@ -162,7 +162,7 @@ class S3
 	 * @static
 	 */
 	public static $sslCert = null;
-	
+
 	/**
 	 * SSL CA cert (only required if you are having problems with your system CA cert)
 	 *
@@ -171,7 +171,7 @@ class S3
 	 * @static
 	 */
 	public static $sslCACert = null;
-	
+
 	/**
 	 * AWS Key Pair ID
 	 *
@@ -180,13 +180,13 @@ class S3
 	 * @static
 	 */
 	private static $__signingKeyPairId = null;
-	
+
 	/**
 	 * Key resource, freeSigningKey() must be called to clear it from memory
 	 *
 	 * @var bool
 	 * @access private
-	 * @static 
+	 * @static
 	 */
 	private static $__signingKeyResource = false;
 
@@ -319,7 +319,7 @@ class S3
 			$rest = new S3Request('HEAD');
 			$rest = $rest->getResponse();
 			$awstime = $rest->headers['date'];
-			$systime = time();			
+			$systime = time();
 			$offset = $systime > $awstime ? -($systime - $awstime) : ($awstime - $systime);
 		}
 		self::$__timeOffset = $offset;
@@ -1827,7 +1827,7 @@ class S3
 			'jpg' => 'image/jpeg', 'jpeg' => 'image/jpeg', 'gif' => 'image/gif',
 			'png' => 'image/png', 'ico' => 'image/x-icon', 'pdf' => 'application/pdf',
 			'tif' => 'image/tiff', 'tiff' => 'image/tiff', 'svg' => 'image/svg+xml',
-			'svgz' => 'image/svg+xml', 'swf' => 'application/x-shockwave-flash', 
+			'svgz' => 'image/svg+xml', 'swf' => 'application/x-shockwave-flash',
 			'zip' => 'application/zip', 'gz' => 'application/x-gzip',
 			'tar' => 'application/x-tar', 'bz' => 'application/x-bzip',
 			'bz2' => 'application/x-bzip2',  'rar' => 'application/x-rar-compressed',
@@ -1910,7 +1910,7 @@ class S3
 }
 
 /**
- * S3 Request class 
+ * S3 Request class
  *
  * @link http://undesigned.org.za/2007/10/22/amazon-s3-php-class
  * @version 0.5.0-dev
@@ -1924,7 +1924,7 @@ final class S3Request
 	 * @access pricate
 	 */
 	private $endpoint;
-	
+
 	/**
 	 * Verb
 	 *
@@ -1932,7 +1932,7 @@ final class S3Request
 	 * @access private
 	 */
 	private $verb;
-	
+
 	/**
 	 * S3 bucket name
 	 *
@@ -1940,7 +1940,7 @@ final class S3Request
 	 * @access private
 	 */
 	private $bucket;
-	
+
 	/**
 	 * Object URI
 	 *
@@ -1948,7 +1948,7 @@ final class S3Request
 	 * @access private
 	 */
 	private $uri;
-	
+
 	/**
 	 * Final object URI
 	 *
@@ -1956,7 +1956,7 @@ final class S3Request
 	 * @access private
 	 */
 	private $resource = '';
-	
+
 	/**
 	 * Additional request parameters
 	 *
@@ -1964,7 +1964,7 @@ final class S3Request
 	 * @access private
 	 */
 	private $parameters = array();
-	
+
 	/**
 	 * Amazon specific request headers
 	 *
@@ -2027,7 +2027,7 @@ final class S3Request
 	*/
 	function __construct($verb, $bucket = '', $uri = '', $endpoint = 's3.amazonaws.com')
 	{
-		
+
 		$this->endpoint = $endpoint;
 		$this->verb = $verb;
 		$this->bucket = $bucket;

--- a/www/themes/plain/index.tpl.php
+++ b/www/themes/plain/index.tpl.php
@@ -12,19 +12,19 @@
       padding: 0;
       margin: 0;
     }
-    
+
     body {
       background-color: #fff;
     }
-    
+
     p, li, td, div {
       font-size: 13px;
     }
-    
+
     img {
       border: 0;
     }
-    
+
     h2 {
       font-size: 1em;
       margin: 5px 0;
@@ -39,12 +39,12 @@
         ul li img {
           vertical-align: middle;
         }
-    
+
     span.size {
       color: #ccc;
       font-size: 10px;
     }
-    
+
     a {
       text-decoration: none;
        color: #666;
@@ -58,7 +58,7 @@
         a:hover span {
           text-decoration: underline;
         }
-    
+
     div.breadcrumb {
       margin-bottom: 5px;
       border-bottom: 1px solid #eee;
@@ -79,7 +79,7 @@
         div.breadcrumb ul li a:hover {
           background-color: #efefef;
         }
-    
+
     #header {
       background-color: #999;
       padding: 10px 15px;
@@ -89,12 +89,12 @@
         color: #000;
         font-size: 26px;
       }
-    
+
     #contents {
       border-top: 1px solid #eee;
        padding: 15px 20px;
     }
-    
+
     #footer {
       border-top: 1px solid #eee;
       padding: 2px 5px 5px;
@@ -165,11 +165,10 @@
     <? endif; ?>
   
   </div>
-  
+
   <div id="footer">
     <p>Powered by <a href="http://github.com/powdahound/s3browser/" target="_blank">S3 Browser</a></p>
   </div>
-
   <? if (isset($config['google-analytics-id'])): ?>
   <script type="text/javascript">
   var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");

--- a/www/themes/plain/index.tpl.php
+++ b/www/themes/plain/index.tpl.php
@@ -114,11 +114,11 @@
   <div id="header">
     <h1><?= $config['page-header'] ?></h1>
   </div>
-  
+
   <div id="contents">
-    
+
     <div class="breadcrumb">
-      Index of 
+      Index of
       <ul>
         <li>
           <a href="<?= $config['base-path'] ?>/"><?= $config['bucket-name'] ?>/</a>
@@ -130,7 +130,7 @@
         <? endforeach ?>
       </ul>
     </div>
-  
+
     <? if (empty($files)): ?>
       <p>No files found.</p>
     <? else: ?>
@@ -147,7 +147,7 @@
     <? foreach ($files as $key => $info): ?>
       <? $asTorrent = (!is_null($config['torrent-threshold']) && $info['size'] > $config['torrent-threshold']); ?>
       <li>
-        <? if (is_array($info['files'])): ?>
+        <? if (array_key_exists('files', $info) && is_array($info['files'])): ?>
           <a href="<?= $config['base-path'] ?>/<?= $info['path'] ?>">
             <img src="<?= $config['base-path'] ?>/themes/plain/img/folder.gif">
             <span><?= $key ?></span>
@@ -163,7 +163,7 @@
     <? endforeach; ?>
     </ul>
     <? endif; ?>
-  
+
   </div>
 
   <div id="footer">


### PR DESCRIPTION
We've come across a situation where we have quite a large number of objects in a bucket. Instead of getting every object at the root path, we only grab the top level initially. Navigating down into the folders grabs the objects for the prefix and moves down. I think the caching could be improved by just caching the first level prefix instead of all, but this appears to be a decent first step from preventing the 30 second timeout loading issue present at the root path with larger buckets.